### PR TITLE
Updated code to solve the build error

### DIFF
--- a/src/Eth.c
+++ b/src/Eth.c
@@ -29,7 +29,7 @@ void Eth_Init(const Eth_ConfigType* CfgPtr) {
 	for (i = 0; i < ETH_DRIVER_MAX_CHANNEL; i++) {
 		if (CfgPtr[i].ctrlcfg.enable_mii == TRUE) {
 			// call function to initialize the MACPHY via SPI
-			macphy_init();
+			(void)macphy_init(CfgPtr[i].ctrlcfg.mac_addres);
 		}
 	}
 }

--- a/src/macphy/enc28j60/enc28j60.c
+++ b/src/macphy/enc28j60/enc28j60.c
@@ -187,7 +187,7 @@ boolean enc28j60_sys_cmd(uint8 cmd) {
 
 //////////////////////////////////////////////
 // Global Functions
-boolean macphy_init(uint8 *mac_addr) {
+boolean macphy_init(const uint8 *mac_addr) {
 	if (mac_addr == NULL) {
 		pr_log("%s: invalid MAC address!\n", __func__);
 		return FALSE;

--- a/src/macphy/enc28j60/enc28j60.h
+++ b/src/macphy/enc28j60/enc28j60.h
@@ -186,5 +186,6 @@ typedef enum {
         MACPHY_MAX_STATE
 } MacPhyStateType;
 
+boolean macphy_init(const uint8 *mac_addr);
 
 #endif


### PR DESCRIPTION
macphy_init function declaration was missing and then function parameters were missing in the calling function. Added const qualifier in the function parameter, as the data we're passing is already a constant.